### PR TITLE
Remove redundant YYLOC global declaration

### DIFF
--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
Cherry-pick from mainline to make it compile with newer version of flex/bison

BTW, TI went forward with u-boot and use another base SRCREV. I tried to rebase your work, it worked flawlessly but doesn't compile because of other issues... I thought keeping as is for now until we eventually decide to upgrade u-boot.